### PR TITLE
Added USE_GKE_GCLOUD_AUTH_PLUGIN=True to nodejs lab

### DIFF
--- a/labs/nodejs/setup.sh
+++ b/labs/nodejs/setup.sh
@@ -9,6 +9,8 @@ export DB_NAME=item_db
 export DB_USER=test-user
 export DB_PASSWORD=CHANGEME
 
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+
 
 
 gcloud services enable \


### PR DESCRIPTION
To prevent the warnings about gcloud auth